### PR TITLE
tests: Cache configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,38 +5,75 @@ import typing as t
 import zipfile
 
 import pytest
+import yaml
 
 from cihai.data.unihan.constants import UNIHAN_FILES
 
 if t.TYPE_CHECKING:
-    from cihai.types import UntypedDict as UnihanOptions
+    from cihai.types import UntypedDict
 
 
-@pytest.fixture()
-def tests_path() -> pathlib.Path:
-    """Return tests/ directory."""
-    return pathlib.Path(__file__).parent
+@pytest.fixture(scope="session")
+def project_path() -> pathlib.Path:
+    return pathlib.Path(__file__).parent.parent
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def cache_path(project_path: pathlib.Path) -> pathlib.Path:
+    return project_path / ".cihai_cache"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_cache_path(cache_path: pathlib.Path) -> None:
+    cache_path.mkdir(parents=True, exist_ok=True)
+
+
+@pytest.fixture(scope="session")
+def tests_path(project_path: pathlib.Path) -> pathlib.Path:
+    return project_path / "tests"
+
+
+@pytest.fixture(scope="session")
 def fixture_path(tests_path: pathlib.Path) -> pathlib.Path:
     """Return tests/fixtures/ directory."""
     return tests_path / "fixtures"
 
 
-@pytest.fixture()
-def test_config_file(fixture_path: pathlib.Path) -> pathlib.Path:
-    """Return test_config.yml file."""
+@pytest.fixture(scope="session")
+def test_config_file_path(fixture_path: pathlib.Path) -> pathlib.Path:
     return fixture_path / "test_config.yml"
 
 
-@pytest.fixture()
-def zip_path(tmp_path: pathlib.Path) -> pathlib.Path:
-    """Return Unihan.zip in temporary path."""
-    return tmp_path / "Unihan.zip"
+@pytest.fixture(scope="session")
+def test_config_file(
+    test_config_file_path: pathlib.Path,
+    unihan_options: "UntypedDict",
+) -> pathlib.Path:
+    with test_config_file_path.open("w") as file:
+        config = yaml.dump(
+            {
+                "database": {"url": "sqlite:///:memory:"},
+                "unihan_options": {
+                    "source": str(unihan_options["source"]),
+                    "work_dir": str(unihan_options["work_dir"]),
+                    "zip_path": str(unihan_options["zip_path"]),
+                },
+            },
+            Dumper=yaml.SafeDumper,
+            indent=True,
+            default_flow_style=False,
+            allow_unicode=True,
+        )
+        file.write(config)
+    return test_config_file_path
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
+def zip_path(cache_path: pathlib.Path) -> pathlib.Path:
+    return cache_path / "Unihan.zip"
+
+
+@pytest.fixture(scope="session")
 def zip_file(zip_path: pathlib.Path, fixture_path: pathlib.Path) -> zipfile.ZipFile:
     """Create and return ZipFile."""
     _files = []
@@ -44,22 +81,22 @@ def zip_file(zip_path: pathlib.Path, fixture_path: pathlib.Path) -> zipfile.ZipF
         _files += [fixture_path / f]
     zf = zipfile.ZipFile(zip_path, "a")
     for _f in _files:
-        zf.write(_f, _f.name)
+        if _f.name not in zf.namelist():
+            zf.write(_f, _f.name)
     zf.close()
     return zf
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def unihan_options(
     zip_file: zipfile.ZipFile,
     zip_path: pathlib.Path,
-    tmp_path: pathlib.Path,
-) -> "UnihanOptions":
-    """Return UnihanOptions for fixture."""
+    cache_path: pathlib.Path,
+) -> "UntypedDict":
     return {
         "source": zip_path,
-        "work_dir": tmp_path,
-        "zip_path": tmp_path / "downloads" / "Moo.zip",
+        "work_dir": cache_path,
+        "zip_path": cache_path / "downloads" / "Moo.zip",
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def unihan_options(
 ) -> "UntypedDict":
     return {
         "source": zip_path,
-        "work_dir": cache_path,
+        "work_dir": cache_path / "work_dir",
         "zip_path": cache_path / "downloads" / "Moo.zip",
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,8 +40,8 @@ def fixture_path(tests_path: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.fixture(scope="session")
-def test_config_file_path(fixture_path: pathlib.Path) -> pathlib.Path:
-    return fixture_path / "test_config.yml"
+def test_config_file_path(cache_path: pathlib.Path) -> pathlib.Path:
+    return cache_path / "test_config.yml"
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures/test_config.yml
+++ b/tests/fixtures/test_config.yml
@@ -1,2 +1,6 @@
 database:
   url: 'sqlite:///:memory:'
+unihan_options:
+  source: /home/t/work/cihai/cihai-cli/.cihai_cache/Unihan.zip
+  work_dir: /home/t/work/cihai/cihai-cli/.cihai_cache
+  zip_path: /home/t/work/cihai/cihai-cli/.cihai_cache/downloads/Moo.zip

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ import yaml
 from cihai_cli.cli import cli
 
 if t.TYPE_CHECKING:
-    from cihai.types import UntypedDict as UnihanOptions
+    from cihai.types import UntypedDict
 
 
 def test_cli(
@@ -29,6 +29,8 @@ def test_cli(
 
     with contextlib.suppress(SystemExit):
         cli(["info"])
+        captured = capsys.readouterr()
+        assert "usage" in captured.out
 
     with contextlib.suppress(SystemExit):
         cli(["reverse"])
@@ -40,7 +42,7 @@ def test_cli_reflects_after_bootstrap(
     caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
     tmpdb_file: pathlib.Path,
-    unihan_options: "UnihanOptions",
+    unihan_options: "UntypedDict",
 ) -> None:
     """High-level, integrative CLI-based test."""
     config = {


### PR DESCRIPTION
1. Caches tests project-wide (`.unihan_cache`, `.cihai_cache`)
2. Caches via `scope='session'` of pytests