### PR TITLE
ci(tests) Verify runtime deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,13 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Test runtime dependencies
+        run: |
+          uv run --no-dev -p python${{ matrix.python-version }} -- python -c '
+          from cihai_cli import cli, __version__
+          print("cihai_cli version:", __version__)
+          '
+
       - name: Install dependencies
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Changes
- Add runtime dependency check in CI using `uv run --no-dev`
- Run check before installing dev dependencies
- Print package version and basic functionality test results
- Document improvement in `CHANGES`

## Summary by Sourcery

Enhance the CI workflow by adding a runtime dependency check to ensure all necessary packages are available before installing development dependencies, and document this improvement.

CI:
- Add a step in the CI workflow to verify runtime dependencies using `uv run --no-dev` before installing development dependencies.

Documentation:
- Document the improvement in the `CHANGES` file.